### PR TITLE
Refactor ECS configuration setup

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -2,21 +2,9 @@
 
 declare(strict_types=1);
 
-use PhpCsFixer\Fixer\Comment\HeaderCommentFixer;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symplify\EasyCodingStandard\ValueObject\Option;
+use Contao\EasyCodingStandard\Set\SetList;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
 
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $containerConfigurator->import('/var/www/metten/contao4/vendor/contao/easy-coding-standard/config/set/contao.php');
-
-    $parameters = $containerConfigurator->parameters();
-    $parameters->set(Option::LINE_ENDING, "\n");
-
-    $services = $containerConfigurator->services();
-    $services
-        ->set(HeaderCommentFixer::class)
-        ->call('configure', [[
-            'header' => "This file is part of bundle contao-clickpress-update.\n\n(c) Stefan Schulz-Lauterbach\n\n@license proprietary",
-        ]])
-    ;
-};
+return ECSConfig::configure()
+    ->withSets([SetList::CONTAO])// Adjust the configuration according to your needs.
+;


### PR DESCRIPTION
Refactor the ECS configuration to use the `ECSConfig` class and `SetList::CONTAO`. This change simplifies the setup by removing manual parameter and service definitions.