### PR TITLE
Fix indentation of API header parameter

### DIFF
--- a/config/parameters.yml
+++ b/config/parameters.yml
@@ -1,5 +1,5 @@
 parameters:
     clickpress_update.token: '%env(CLICKPRESS_UPDATE)%'
     api_header:
-    "Access-Control-Allow-Origin": "*"
+        "Access-Control-Allow-Origin": "*"
 


### PR DESCRIPTION
## Summary
- fix indentation in parameters.yml so API header config is parsed correctly

## Testing
- `composer validate --no-check-all --strict` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68471c45b4b8832da09d158420f4e5bf